### PR TITLE
Add github actions CI and build x64 Linux application instead of ia32

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,57 @@
+# Workflow to build on each commit and create a release on tags
+
+name: main
+
+# Controls when the workflow will run
+# Triggers the workflow on push or pull request events
+on: [push, pull_request, workflow_dispatch]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # Linux and windows build, MacOS build is not supported on a Linux host
+  linux:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v4
+
+      # Install nodejs + npm
+      - uses: actions/setup-node@v3
+
+
+      - name: Install wine
+        run: |
+          sudo dpkg --add-architecture i386
+          sudo apt-get update
+          sudo apt-get install -y wine wine32
+
+      # Build the application
+      - name: Build
+        run: |
+          npm install
+          npm run dist:lin
+          npm run dist:win
+
+      - name: Upload Built Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          # Artifact name
+          name: "PTree-linux" # optional, default is artifact
+          # A file, directory or wildcard pattern that describes what to upload
+          path: |
+            bin/PTree-linux.zip
+            bin/PTree-windows.zip
+
+      # Uncomment for artifact publishing on tags
+      # - name: Publish
+      #   uses: softprops/action-gh-release@v1
+      #   if: startsWith(github.ref, 'refs/tags/')
+      #   with:
+      #     files: |
+      #       bin/PTree-linux.zip
+      #       bin/PTree-windows.zip
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -61,7 +61,7 @@
   },
   "linux": {
     "icon"       : "resources/png/app",
-    "target"     : {"target":"dir", "arch": "ia32"},
+    "target"     : {"target":"dir", "arch": "x64"},
     "extraFiles" : [
       {"from": "resources/example.ptree", "to": "example.ptree"},
       {"from": "resources/equations.pdf", "to": "equations.pdf"},

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "build:mac": "electron-builder --config electron-builder.json --mac   --dir",
     "build:win": "electron-builder --config electron-builder.json --win   --dir",
     "build:lin": "electron-builder --config electron-builder.json --linux --dir",
-    "dist:mac": " electron-builder --config electron-builder.json --mac   ; cd bin ; mv PTree.dmg PTree-macos.dmg ; rm -rf mac",
-    "dist:win": " electron-builder --config electron-builder.json --win   ; cd bin ; mv win-unpacked        PTree ; rm -f PTree-windows.zip ; zip -r -X -y -q PTree-windows.zip PTree/ ; rm -rf PTree",
-    "dist:lin": " electron-builder --config electron-builder.json --linux ; cd bin ; mv linux-unpacked PTree ; rm -f PTree-linux.zip   ; zip -r -X -y -q PTree-linux.zip   PTree/ ; rm -rf PTree",
+    "dist:mac": " electron-builder --config electron-builder.json --mac   && cd bin && mv PTree.dmg PTree-macos.dmg && rm -rf mac",
+    "dist:win": " electron-builder --config electron-builder.json --win   && cd bin && mv win-unpacked        PTree && rm -f PTree-windows.zip && zip -r -X -y -q PTree-windows.zip PTree/ && rm -rf PTree",
+    "dist:lin": " electron-builder --config electron-builder.json --linux && cd bin && mv linux-unpacked PTree && rm -f PTree-linux.zip   && zip -r -X -y -q PTree-linux.zip   PTree/ && rm -rf PTree",
     "dist:all": " npm run dist:mac  && npm run dist:win  && npm run dist:lin"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build:lin": "electron-builder --config electron-builder.json --linux --dir",
     "dist:mac": " electron-builder --config electron-builder.json --mac   ; cd bin ; mv PTree.dmg PTree-macos.dmg ; rm -rf mac",
     "dist:win": " electron-builder --config electron-builder.json --win   ; cd bin ; mv win-unpacked        PTree ; rm -f PTree-windows.zip ; zip -r -X -y -q PTree-windows.zip PTree/ ; rm -rf PTree",
-    "dist:lin": " electron-builder --config electron-builder.json --linux ; cd bin ; mv linux-ia32-unpacked PTree ; rm -f PTree-linux.zip   ; zip -r -X -y -q PTree-linux.zip   PTree/ ; rm -rf PTree",
+    "dist:lin": " electron-builder --config electron-builder.json --linux ; cd bin ; mv linux-unpacked PTree ; rm -f PTree-linux.zip   ; zip -r -X -y -q PTree-linux.zip   PTree/ ; rm -rf PTree",
     "dist:all": " npm run dist:mac  && npm run dist:win  && npm run dist:lin"
   },
   "repository": {


### PR DESCRIPTION
This PR does this:

- Github actions to auto-build the application and generate artifacts (visible in actions tab on github).

If a draft github release exists when building, I think electron-builder will push artifact automatically, but this might require configuration.
This can be disabled using `publish: "never"` in the configuration.

- Change the Linux binary from ia32 to amd64. The ia32 binary wasn't working on Debian Sid (with a segmentation fault).

- make npm run dist:* fail when electron-builder fails by replacing ` ; ` by ` & `